### PR TITLE
Adding tests for sendWebPush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ node_js:
   - 'stable'
 
 install:
-  - npm install -g mocha
   - npm install

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1,0 +1,29 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+/* eslint-env node */
+
+'use strict';
+
+const gulp = require('gulp');
+const mocha = require('gulp-mocha');
+
+gulp.task('test:manual', function() {
+  return gulp.src('./test/*.js', {read: false})
+    .pipe(mocha())
+    .on('error', () => {
+      process.exit(1);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.1",
     "jsdoc": "^3.4.0",
+    "gulp-mocha": "^2.2.0",
     "require-dir": "^0.3.0",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3"
   },
   "scripts": {
-    "test": "gulp lint && mocha",
+    "test": "gulp lint test:manual",
     "build-docs": "./node_modules/jsdoc/jsdoc.js -c jsdoc.json"
   },
   "keywords": [

--- a/src/encrypt.js
+++ b/src/encrypt.js
@@ -30,7 +30,7 @@ const MAX_PAYLOAD_LENGTH = 4078;
  * - {@link https://en.wikipedia.org/wiki/Elliptic_curve_Diffie%E2%80%93Hellman}
  * - {@link https://tools.ietf.org/html/draft-ietf-webpush-encryption}
  *
- * @param  {String} message       The message to be sent
+ * @param  {String|Buffer} message The message to be sent
  * @param  {Object} subscription  The subscription details for the client
  * @param  {number} paddingLength Number of bytes of padding to use
  * @return {Object}               An Object containing the encrypted payload and
@@ -42,7 +42,15 @@ function encrypt(message, subscription, paddingLength) {
 
   // Create Buffers for all of the inputs
   const paddingBuffer = makePadding(paddingLength);
-  const messageBuffer = new Buffer(message, 'utf8');
+  let messageBuffer;
+
+  if (typeof message === 'string') {
+    messageBuffer = new Buffer(message, 'utf8');
+  } else if (message instanceof Buffer) {
+    messageBuffer = message;
+  } else {
+    throw new Error('Message must be a String or a Buffer');
+  }
 
   // The maximum size of the message + padding is 4078 bytes
   if ((messageBuffer.length + paddingLength) > MAX_PAYLOAD_LENGTH) {

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,6 @@ const EXAMPLE_SERVER_KEYS = {
   public: 'BOg5KfYiBdDDRF12Ri17y3v+POPr8X0nVP2jDjowPVI/DMKU1aQ3OLdPH1iaakvR9/PHq6tNCzJH35v/JUz2crY=',
   private: 'uDNsfsz91y2ywQeOHljVoiUg3j5RGrDVAswRqjP3v90='
 };
-
 const EXAMPLE_SALT = 'AAAAAAAAAAAAAAAAAAAAAA==';
 
 const EXAMPLE_INPUT = 'Hello, World.';
@@ -57,6 +56,11 @@ const INVALID_P256DH_SUBSCRIPTION = {
 
 const SUBSCRIPTION_NO_KEYS = {
   endpoint: 'https://example-endpoint.com/example/1234'
+};
+
+const GCM_SUBSCRIPTION_EXAMPLE = {
+  original: 'https://android.googleapis.com/gcm/send/AAAAAAAAAAA:AAA91AAAA2_A7AAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAA9AAA_AAAA8AAAAAA5-AAAAAA2AAAA_AAAAA4A51A_A3AAA1AAAAAAAAAAAAAAA3AAAAAAAAA6AA2AAAAAAAA80AAAAAA',
+  webpush: 'https://gcm-http.googleapis.com/gcm/AAAAAAAAAAA:AAA91AAAA2_A7AAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAA9AAA_AAAA8AAAAAA5-AAAAAA2AAAA_AAAAA4A51A_A3AAA1AAAAAAAAAAAAAAA3AAAAAAAAA6AA2AAAAAAAA80AAAAAA'
 };
 
 const SALT_LENGTH = 16;
@@ -205,6 +209,174 @@ describe('Test the Libraries Top Level API', function() {
 
       expect(() => library.encrypt(EXAMPLE_INPUT, VALID_SUBSCRIPTION, 4080))
         .to.throw('Payload is too large. The max number of bytes is 4078, input is 13 bytes plus 4080 bytes of padding.')
+    });
+  });
+
+  describe('Test sendWebPush() method', function() {
+    it('should throw an error when no input provided', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush()
+      ).to.throw('sendWebPush() expects a subscription endpoint with ' +
+        'an endpoint parameter.');
+    });
+
+    it('should throw an error when the subscription object has no endpoint', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush({})
+      ).to.throw('sendWebPush() expects a subscription endpoint with ' +
+        'an endpoint parameter.');
+    });
+
+    it('should throw an error when a message is passed in with no subscription', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush('Message')
+      ).to.throw('sendWebPush() expects a subscription endpoint with ' +
+        'an endpoint parameter.');
+    });
+
+    it('should throw an error when a subscription is passed in with array as payload data', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush([
+          {
+            hello: 'world'
+          },
+          'This is a test',
+          Promise.resolve('Promise Resolve'),
+          Promise.reject('Promise Reject')
+        ], VALID_SUBSCRIPTION)
+      ).to.throw('Message must be a String or a Buffer');
+    });
+
+    it('should throw an error when a subscription with no encryption details is passed in with string as payload data', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush('Hello, World!', {
+          endpoint: 'http://fakendpoint'
+        })
+      ).to.throw('Subscription has no encryption details.');
+    });
+
+    it('should attempt a web push protocol request', function() {
+      const requestReplacement = {
+        post: (endpoint, data, cb) => {
+          endpoint.should.equal(VALID_SUBSCRIPTION.endpoint);
+
+          Buffer.isBuffer(data.body).should.equal(true);
+          data.headers.Encryption.should.have.length(27);
+          data.headers['Crypto-Key'].should.have.length(90);
+
+          cb(
+            null,
+            {
+              statusCode: 200,
+              statusMessage: 'Status message'
+            },
+            'Response body'
+          );
+        }
+      };
+      const pushProxy = proxyquire('../src/push.js', {
+        'request': requestReplacement
+      });
+      const library = proxyquire('../src/index.js', {
+        './push': pushProxy
+      });
+      return library.sendWebPush('Hello, World!', VALID_SUBSCRIPTION)
+      .then(response => {
+        response.statusCode.should.equal(200);
+        response.statusMessage.should.equal('Status message');
+        response.body.should.equal('Response body');
+      });
+    });
+
+    it('should attempt a web push protocol request for GCM', function() {
+      const API_KEY = 'AAAA';
+      const gcmSubscription = {
+        endpoint: GCM_SUBSCRIPTION_EXAMPLE.original,
+        keys: VALID_SUBSCRIPTION.keys
+      };
+      const requestReplacement = {
+        post: (endpoint, data, cb) => {
+          endpoint.should.equal(GCM_SUBSCRIPTION_EXAMPLE.webpush);
+
+          Buffer.isBuffer(data.body).should.equal(true);
+          data.headers.Encryption.should.have.length(27);
+          data.headers['Crypto-Key'].should.have.length(90);
+          data.headers.Authorization.should.equal('key=' + API_KEY);
+
+          cb(
+            null,
+            {
+              statusCode: 200,
+              statusMessage: 'Status message'
+            },
+            'Response body'
+          );
+        }
+      };
+
+      const pushProxy = proxyquire('../src/push.js', {
+        'request': requestReplacement
+      });
+      const library = proxyquire('../src/index.js', {
+        './push': pushProxy
+      });
+      return library.sendWebPush('Hello, World!', gcmSubscription, API_KEY)
+      .then(response => {
+        response.statusCode.should.equal(200);
+        response.statusMessage.should.equal('Status message');
+        response.body.should.equal('Response body');
+      });
+    });
+
+    it('should throw an error when not providing an AuthToken for a GCM subscription', function() {
+      const gcmSubscription = {
+        endpoint: GCM_SUBSCRIPTION_EXAMPLE.original,
+        keys: VALID_SUBSCRIPTION.keys
+      };
+
+      const library = require('../src/index.js');
+      expect(
+        () => library.sendWebPush('Hello, World!', gcmSubscription)
+      ).to.throw('GCM requires an Auth Token parameter');
+    });
+
+    it('should handle errors from request', function() {
+      const EXAMPLE_ERROR = 'Example Error';
+
+      const requestReplacement = {
+        post: (endpoint, data, cb) => {
+          endpoint.should.equal(VALID_SUBSCRIPTION.endpoint);
+
+          Buffer.isBuffer(data.body).should.equal(true);
+          data.headers.Encryption.should.have.length(27);
+          data.headers['Crypto-Key'].should.have.length(90);
+
+          cb(EXAMPLE_ERROR);
+        }
+      };
+      const pushProxy = proxyquire('../src/push.js', {
+        'request': requestReplacement
+      });
+      const library = proxyquire('../src/index.js', {
+        './push': pushProxy
+      });
+      return library.sendWebPush('Hello, World!', VALID_SUBSCRIPTION)
+      .then(() => {
+        throw new Error('The promise was expected to reject.');
+      })
+      .catch(err => {
+        err.should.equal(EXAMPLE_ERROR);
+      });
     });
   });
 });


### PR DESCRIPTION
@gauntface This is your PR #11 which I have rebased, fixed after changes on master, and then made a few small changes to.

Biggest functional change is that `encrypt` now let's `message` be a `String` or a `Buffer`. It should really have been in it's own PR, I guess, but I thought of it while doing this one. `¯\_(ツ)_/¯`
