### PR TITLE
Adding Docs + Publishing NPM Script + README Tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ node_js:
 
 install:
   - npm install
+
+script:
+  - npm test
+  - ./node_modules/sw-testing-helpers/project/publish-docs.sh master

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Push Encryption (node)
 ----------------------
 
-[![Travis Build Status](https://travis-ci.org/GoogleChrome/push-encryption-node.svg?branch=master)](https://travis-ci.org/GoogleChrome/push-encryption-node)
-
-[![Dependency Badge from David](https://david-dm.org/GoogleChrome/push-encryption-node.svg)](https://david-dm.org/GoogleChrome/push-encryption-node)
+[![Travis Build Status](https://travis-ci.org/GoogleChrome/push-encryption-node.svg?branch=master)](https://travis-ci.org/GoogleChrome/push-encryption-node) [![Dependency Badge from David](https://david-dm.org/GoogleChrome/push-encryption-node.svg)](https://david-dm.org/GoogleChrome/push-encryption-node) [![devDependency Status](https://david-dm.org/GoogleChrome/push-encryption-node/dev-status.svg)](https://david-dm.org/GoogleChrome/push-encryption-node#info=devDependencies)
 
 This library provides the functions necessary to encrypt a payload for sending
 with the Web Push protocol. It also includes a helper function for actually
@@ -45,6 +43,11 @@ if (subscription.endpoint.indexOf('https://android.googleapis.com/gcm/send/') ==
   webpush.sendWebPush('A message for Chrome', subscription, MY_GCM_KEY);
 }
 ```
+
+Docs
+-----
+
+You can [find docs here](https://googlechrome.github.io/push-encryption-node/).
 
 Support
 -------

--- a/package.json
+++ b/package.json
@@ -11,15 +11,19 @@
     "eslint-config-google": "^0.3.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.1",
-    "jsdoc": "^3.4.0",
     "gulp-mocha": "^2.2.0",
-    "require-dir": "^0.3.0",
+    "jsdoc": "^3.4.0",
     "proxyquire": "^1.7.4",
-    "sinon": "^1.17.3"
+    "require-dir": "^0.3.0",
+    "sinon": "^1.17.3",
+    "sw-testing-helpers": "0.0.12"
   },
   "scripts": {
     "test": "gulp lint test:manual",
-    "build-docs": "./node_modules/jsdoc/jsdoc.js -c jsdoc.json"
+    "build-docs": "jsdoc -c jsdoc.json",
+    "bundle": "./project/copy-bundle-files.sh",
+    "publish": "./node_modules/sw-testing-helpers/project/publish-release.sh",
+    "build": "echo \"Skipping build step\""
   },
   "keywords": [
     "web",

--- a/project/copy-bundle-files.sh
+++ b/project/copy-bundle-files.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+#########################################################################
+#
+# GUIDE TO USE OF THIS SCRIPT
+#
+#########################################################################
+#
+# - This script is used by npm run bundle in this probject and serves
+#   solely as an example
+#
+#########################################################################
+
+if [ "$BASH_VERSION" = '' ]; then
+ echo "    Please run this script via this command: './project/copy-bundle-files.sh'"
+ exit 1;
+fi
+
+if [ -z "$1" ]; then
+  echo "    Bad input: Expected a directory as the first argument for the path to put the final bundle files into (i.e. ./tagged-release)";
+  exit 1;
+fi
+
+# This isn't needed unless run outside of publish-release script
+mkdir -p $1
+
+cp -r ./docs $1
+cp -r ./src $1
+cp LICENSE $1
+cp package.json $1
+cp README.md $1

--- a/test/index.js
+++ b/test/index.js
@@ -208,7 +208,7 @@ describe('Test the Libraries Top Level API', function() {
       ).to.throw('Payload is too large. The max number of bytes is 4078, input is 5000 bytes plus 0 bytes of padding.');
 
       expect(() => library.encrypt(EXAMPLE_INPUT, VALID_SUBSCRIPTION, 4080))
-        .to.throw('Payload is too large. The max number of bytes is 4078, input is 13 bytes plus 4080 bytes of padding.')
+        .to.throw('Payload is too large. The max number of bytes is 4078, input is 13 bytes plus 4080 bytes of padding.');
     });
   });
 


### PR DESCRIPTION
This adds a publishing step and adds doc generation to the project.

This was largely kicked off by: https://github.com/GoogleChrome/push-encryption-node/issues/22

@addyosmani @jeffposnick @surma would one of you kind souls give this PR a review?
