### PR TITLE
Just use jsdoc via implicit .bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "gulp lint test:manual",
-    "build-docs": "./node_modules/jsdoc/jsdoc.js -c jsdoc.json"
+    "build-docs": "jsdoc -c jsdoc.json"
   },
   "keywords": [
     "web",


### PR DESCRIPTION
R: @gauntface 

You don't need to point to the `./node_modules/...` path when there's already an alias in `.bin` that `npm` [will implicitly add](http://firstdoit.com/npm-scripts/#npmscriptsunderstandbin) to your `PATH`.

This should help with Windows compatibility as a side effect.
