### PR TITLE
Add content-encoding header - Mozilla Push Server requires it (Firefo…

### DIFF
--- a/src/push.js
+++ b/src/push.js
@@ -61,6 +61,7 @@ function sendWebPush(message, subscription, authToken) {
 
   const payload = encrypt(message, subscription);
   const headers = {
+    'Content-Encoding': 'aesgcm',
     'Encryption': `salt=${ub64(payload.salt)}`,
     'Crypto-Key': `dh=${ub64(payload.serverPublicKey)}`
   };


### PR DESCRIPTION
…x 47)

Was messing around with getting my push notifications working in Firefox. Firefox 47 creates a subscription object similar to Chrome 50's:

```
{
  endpoint: ...,
  keys: {
    p256dh: ...,
    auth: ...
  }
}
```

Code seems to work as is for Firefox 47 and Mozilla Push Service (and still looks fine for Chrome) with this one field added to the header.
