### PR TITLE
check input earlier to prevent misuse

### DIFF
--- a/src/push.js
+++ b/src/push.js
@@ -49,7 +49,7 @@ function ub64(buffer) {
  * Sends a message using the Web Push protocol
  *
  * @memberof web-push-encryption
- * @param  {String}   message      The message to send
+ * @param  {String|Buffer} message      The message to send
  * @param  {Object}   subscription The subscription details for the client we
  *                                 are sending to
  * @param {Number}    paddingLength The number of bytes of padding to add to the
@@ -73,12 +73,17 @@ function sendWebPush(message, subscription, paddingLength) {
   };
   let body;
 
-  if (message && message.length > 0) {
-    const payload = encrypt(message, subscription, paddingLength);
-    headers['Content-Encoding'] = 'aesgcm';
-    headers.Encryption = `salt=${ub64(payload.salt)}`;
-    headers['Crypto-Key'] = `dh=${ub64(payload.serverPublicKey)}`;
-    body = payload.ciphertext;
+  if (message) {
+    if (typeof message != 'string' && !(message instanceof Buffer)) {
+      throw new Error('Message must be a String or a Buffer');
+    }
+    if (message.length > 0) {
+      const payload = encrypt(message, subscription, paddingLength);
+      headers['Content-Encoding'] = 'aesgcm';
+      headers.Encryption = `salt=${ub64(payload.salt)}`;
+      headers['Crypto-Key'] = `dh=${ub64(payload.serverPublicKey)}`;
+      body = payload.ciphertext;
+    }
   }
 
   if (endpoint.indexOf(TEMP_GCM_URL) !== -1) {

--- a/test/index.js
+++ b/test/index.js
@@ -263,6 +263,14 @@ describe('Test the Libraries Top Level API', function() {
       ).to.throw('Message must be a String or a Buffer');
     });
 
+    it('should throw an error when a subscription is passed in with a random object as payload data', function() {
+      const library = require('../src/index.js');
+
+      expect(
+        () => library.sendWebPush({random: 1}, VALID_SUBSCRIPTION)
+      ).to.throw('Message must be a String or a Buffer');
+    });
+
     it('should throw an error when a subscription with no encryption details is passed in with string as payload data', function() {
       const library = require('../src/index.js');
 


### PR DESCRIPTION
Currently the code sanity-checks e.g. `Array` (since it has a `.length` property) but silently doesn't send non-string/etc data.

I could probably move this around (and make `encrypt()` only take a `Buffer`) to reduce code reuse but that would involve fixing lots of tests. Let me know if that's preferred.
